### PR TITLE
fix GHCR login

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,8 +37,8 @@ jobs:
       uses: docker/login-action@v2.1.0
       with:
         registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GHCR_TOKEN }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build Image and Push to GHCR
       uses: docker/build-push-action@v3.2.0
       with:


### PR DESCRIPTION
See https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#upgrading-a-workflow-that-accesses-a-registry-using-a-personal-access-token and https://github.com/docker/login-action/tree/f4ef78c080cd8ba55a85445d5b36e214a81df20a#github-container-registry