### PR TITLE
Use `person-chalkboard` instead of `head-side-cough` for docs logo

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,7 @@ theme:
   name: material
   favicon: assets/favicon.png
   icon:
-    logo: fontawesome/solid/head-side-cough
+    logo: fontawesome/solid/person-chalkboard
   palette:
     - scheme: default
       toggle:


### PR DESCRIPTION
Thanks for the suggestion @edrogers !