### PR TITLE
Add copy-to-clipboard button to docs code blocks

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,10 @@
 
 ## `0.4.4` | *Unreleased*
 
+### Added
+
+- [#185](https://github.com/JoshKarpel/spiel/pull/185) The docs page now includes copy-to-clipboard buttons on all code snippets.
+
 ## `0.4.3` | 2023-01-02
 
 ### Added

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ theme:
     - navigation.indexes
     - toc.follow
     - content.code.annotate
+    - content.code.copy
 
 plugins:
   - tags


### PR DESCRIPTION
Add a copy-to-clipboard button for each code snippet on the docs page. Uses [the Code Copy Button feature from the `mkdocs` Material theme](https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#code-copy-button)

Fixes #184 

Tasks
-----

- [X] Updated changelog.
- [X] Updated documentation.
